### PR TITLE
Update instructions to run docker compose file with kubernetes

### DIFF
--- a/kubernetes-desktop.md
+++ b/kubernetes-desktop.md
@@ -44,7 +44,7 @@ Deploy the app to Kubernetes as a stack using the [compose file](./kubernetes-de
 
 ```
 export DOCKER_ORCHESTRATOR=kubernetes
-docker stack deploy voting-app -c docker-compose.yml
+docker stack deploy voting-app -c docker-compose-k8s.yml
 ```
 
 Docker for Mac includes the [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) command line, so you can work directly with the Kube cluster. Check the services are up, and you should see output like this:


### PR DESCRIPTION
Running with the current version gives the following :
```
$ docker stack deploy voting-app -c docker-compose.yml
Ignoring unsupported options: build

Ignoring deprecated options:

container_name: Setting the container name is not supported.

Creating service voting-app_result
Error response from daemon: rpc error: code = 3 desc = ContainerSpec: image reference must be provided
```
While using docker-compose-k8s.yml works:
```
$ docker stack deploy voting-app -c docker-compose-k8s.yml
Creating network voting-app_default
Creating service voting-app_worker
Creating service voting-app_visualizer
Creating service voting-app_redis
Creating service voting-app_db
Creating service voting-app_vote
Creating service voting-app_result
```