### PR TITLE
Set movieplex lb nodePort to 30800

### DIFF
--- a/mta-java.md
+++ b/mta-java.md
@@ -103,7 +103,7 @@ React uses Node.js to build a static site for the interface. The Dockerfile is m
 
 ```
 FROM node:latest
-ENV API_HOST=pwd10-0-16-3-8080.host4.labs.play-with-docker.com
+ENV API_HOST=ip172-18-0-7-bapfmbugera000cfb1cg.direct.beta-hybrid.play-with-docker.com:30080
 WORKDIR /usr/src/react-client
 COPY . .
 RUN npm install
@@ -111,6 +111,8 @@ RUN npm run build
 EXPOSE 3000
 CMD ["npm", "run", "start"]
 ```
+
+**Important:** make sure that there is only one API_HOST set, and its value is the base url of the Play with Docker lab!
 
 # Step 3: Moving from Wildfly to Tomcat EE
 
@@ -223,6 +225,7 @@ spec:
   ports:
     - name: movieplex7
       port: 8080
+      nodePort: 30800
   selector: 
     app: movieplex7
 ---


### PR DESCRIPTION
The add_ee_pwd_host script hardcodes the port as 30080, however since the kubernetes deployment file does not specify the nodePort, UCD may use a different value, which breaks communication between the react client and the movieplex app.

As a solution, hardcode nodePort value to 30800 on the Movieplex load balancer.